### PR TITLE
Update ember-screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,6 @@
     "ember-data": "1.13.15",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
-    "ember-screen": "0.0.2"
+    "ember-screen": "0.0.3"
   }
 }


### PR DESCRIPTION
This fixes a bug in Ember Screen where breakpoint properties would not trigger updates if `width` had never been used.
